### PR TITLE
Translate "Press / to search" string to Russian

### DIFF
--- a/lang/ru.json
+++ b/lang/ru.json
@@ -74,6 +74,7 @@
 	"Run Action": "Запустить действие",
 	"Select Action": "Выбрать действие",
 	"Search": "Искать",
+	"Press / to search": "Нажмите \"/\" для поиска",
 	"Select All": "Выбрать все",
 	"Select All Matching": "Выбрать все подходящие",
 	"Something went wrong.": "Что-то пошло не так.",


### PR DESCRIPTION
Hi!

There is a missing translation string from recent Nova update.